### PR TITLE
Bugfix/features link to subcomplex participant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "complexviewer",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "A network visualisation that displays molecular interaction data, including detailed residue-level information such as binding sites. Used in EBI's Complex Portal and elsewhere.",
   "author": {
     "name": "Colin Combe",

--- a/src/js/clone-complex-refs.js
+++ b/src/js/clone-complex-refs.js
@@ -25,7 +25,6 @@ export function cloneComplexRefs(json) {
 
             // If we found an interaction then we need to clone it.
             if (foundInteraction) {
-
                 let count = instanceCount.get(complexToClone.interactorRef);
                 if (count) {
                     count = count + 1;
@@ -37,62 +36,131 @@ export function cloneComplexRefs(json) {
                 let i = count;
 
                 if (i > 1) {
-                    // this looks weird, don't think it'll work if more than 2 refs to complex?
-                    complexToClone.interactorRef = `${complexToClone.interactorRef}_${i}`;
-
-                    // update features of complex
-                    if (complexToClone.features) {
-                        complexToClone.features.forEach(function (feature) {
-                            feature.copiedfrom = feature.id;
-                            // feature.id = `${feature.id}_${i}`;
-                            // Also, adjust our sequence data
-                            feature.sequenceData.forEach(function (sequenceData) {
-                                sequenceData.participantRef = `${sequenceData.participantRef}_${i}`;
-                                //~ sequenceData.interactorRef = clonedInteractor.id;
-                            });
-                        });
-                    }
-
-                    const clonedInteraction = JSON.parse(JSON.stringify(foundInteraction));
-                    clonedInteraction.sourceId = clonedInteraction.id;
-                    clonedInteraction.id = `${clonedInteraction.id}_${i}`;
-
-                    json.data.push(clonedInteraction);
-
-                    for (let participant of clonedInteraction.participants) {
-                        /********** PARTICIPANTS **********/
-                        const clonedParticipant = participant;//JSON.parse(JSON.stringify(participant));
-
-                        clonedParticipant.id = `${clonedParticipant.id}_${i}`;
-
-                        // We need to relink to our binding site IDs:
-                        if (clonedParticipant.features) {
-                            clonedParticipant.features.forEach(function (feature) {
-
-                                // feature.copiedfrom = feature.id;
-                                feature.id = `${feature.id}_${i}`;
-                                // Also, adjust our sequence data
-                                feature.sequenceData.forEach(function (sequenceData) {
-                                    sequenceData.participantRef = clonedParticipant.id;
-                                    //~ sequenceData.interactorRef = clonedInteractor.id;
-                                });
-
-                                const lnCount = feature.linkedFeatures.length;
-                                for (let ln = 0; ln < lnCount; ln++){
-                                    // console.log(linkedFeature);
-                                    feature.linkedFeatures[ln] = `${feature.linkedFeatures[ln]}_${i}`;
-                                }
-
-                            });
-                        }
-                    }
+                    cloneComplexParticipant(complexToClone, i);
+                    json.data.push(cloneComplexInteraction(foundInteraction, i));
                 }
             }
         });
 
     });
 
+    // After all the complexes and participants have been cloned due to stoichiometry,
+    // we need to check if any subcomplex needs to recursively also clone their participants.
+    return cloneComplexClonesRecursively(json);
+}
+
+function cloneComplexClonesRecursively(json) {
+
+    // We'll need collections of our interactions and interactors for later..
+    const interactions = json.data.filter(function (interaction) {
+        return interaction.object === "interaction";
+    });
+
+    // Loop through our interactions
+    interactions.forEach(function (interaction) {
+        json.data.push(...cloneClonedComplexParticipants(interactions, interaction));
+    });
+
     return json;
+}
+
+function cloneClonedComplexParticipants(interactions, interaction) {
+    const clonesInteractions = [];
+
+    // We only try to clone participants from already cloned complexes
+    const match = interaction.id.match(/.*_([0-9])+$/);
+    if (match) {
+        const i = match[1];
+
+        // Get a collection of participants with 'complex' in interactorRef - not ideal way to get complexes
+        const complexesToClone = interaction.participants.filter(function (participant) {
+            if (participant.interactorRef.indexOf("complex") !== -1) {
+                return participant;
+            }
+        });
+
+        // Loop through our participants that need expanding
+        complexesToClone.forEach(function (complexToClone) {
+
+            // Do we have an interaction
+            const foundInteraction = findFirstObjWithAttr(interactions, "id", complexToClone.interactorRef);
+
+            // If we found an interaction then we need to clone it.
+            if (foundInteraction) {
+                cloneComplexParticipant(complexToClone, i);
+                const clonedInteraction = cloneComplexInteraction(foundInteraction, i);
+                clonesInteractions.push(clonedInteraction);
+                clonesInteractions.push(...cloneClonedComplexParticipants(interactions, clonedInteraction));
+            }
+        });
+    }
+
+    return clonesInteractions;
+}
+
+function cloneComplexParticipant(complexToClone, i) {
+    // this looks weird, don't think it'll work if more than 2 refs to complex?
+    complexToClone.interactorRef = `${complexToClone.interactorRef}_${i}`;
+
+    // update features of complex
+    if (complexToClone.features) {
+        complexToClone.features.forEach(function (feature) {
+            feature.copiedfrom = feature.id;
+            // feature.id = `${feature.id}_${i}`;
+            // Also, adjust our sequence data
+            feature.sequenceData.forEach(function (sequenceData) {
+
+                // Participant Ref may have already been updated, so we don't want to update it twice
+                const match = sequenceData.participantRef.match(/^(.*)_([0-9])+$/);
+                if (!match) {
+                    sequenceData.participantRef = `${sequenceData.participantRef}_${i}`;
+                }
+                //~ sequenceData.interactorRef = clonedInteractor.id;
+            });
+        });
+    }
+}
+
+function cloneComplexInteraction(interaction, i) {
+    const clonedInteraction = JSON.parse(JSON.stringify(interaction));
+    clonedInteraction.sourceId = clonedInteraction.id;
+    clonedInteraction.id = `${clonedInteraction.id}_${i}`;
+
+    for (let participant of clonedInteraction.participants) {
+        /********** PARTICIPANTS **********/
+        const clonedParticipant = participant;//JSON.parse(JSON.stringify(participant));
+
+        clonedParticipant.id = `${clonedParticipant.id}_${i}`;
+
+        // We need to relink to our binding site IDs:
+        if (clonedParticipant.features) {
+            clonedParticipant.features.forEach(function (feature) {
+
+                // feature.copiedfrom = feature.id;
+                feature.id = `${feature.id}_${i}`;
+                // Also, adjust our sequence data
+                feature.sequenceData.forEach(function (sequenceData) {
+                    // sequenceData.participantRef = clonedParticipant.id;
+                    //~ sequenceData.interactorRef = clonedInteractor.id;
+
+                    // Participant Ref may have already been updated, so we don't want to update it twice
+                    const match = sequenceData.participantRef.match(/^(.*)_([0-9])+$/);
+                    if (!match) {
+                        sequenceData.participantRef = `${sequenceData.participantRef}_${i}`;
+                    }
+                });
+
+                const lnCount = feature.linkedFeatures.length;
+                for (let ln = 0; ln < lnCount; ln++){
+                    // console.log(linkedFeature);
+                    feature.linkedFeatures[ln] = `${feature.linkedFeatures[ln]}_${i}`;
+                }
+
+            });
+        }
+    }
+
+    return clonedInteraction;
 }
 
 // Returns the first object in an array that has an attribute with a matching value.


### PR DESCRIPTION
Currently, complex viewer is not working with this complex https://www.ebi.ac.uk/complexportal/complex/CPX-7083

At first, we thought it was related to multiple levels of subcomplexes and stoichiometry greater than 1. But looking more into the console errors, and debugging the complex viewer, the issue has more to do with the features and the participant references.

We currently go through complexes that are referenced as participants in multiple interactions nodes, and we clone them. When these complexes have subcomplexes of their own, we do not clone them. This is normally not an issue, but if these cloned complexes have features that link to participants of their subcomplexes, then the participant reference in those features are wrong, causing an error.

With this fix, what we do is:
1. Go though all complex that are participants and check if they need to be cloned.
2. If they are cloned, add then to the list of interactions (as usual), and add them to a list of new complexes to check.
3. After all original complexes have been checked, then we go through the new list of cloned complexes and do these same 3 steps recursively.
Doing this we make sure we clone not only 1 level of subcomplexes, but all nested levels.

Current complex not working: https://www.ebi.ac.uk/complexportal/complex/CPX-7083
After the fix:
![Screenshot 2025-04-11 at 16 13 42](https://github.com/user-attachments/assets/17311fbf-bbfd-4917-b779-e829d7b6a3c0)
